### PR TITLE
fix: nomic embed evals

### DIFF
--- a/src/encoder_model.py
+++ b/src/encoder_model.py
@@ -124,7 +124,7 @@ class RetrievalModel(DRESModel):
         if self.prefix_type == 'query_or_passage':
             input_texts = ['passage: {}'.format(t) for t in input_texts]
         elif self.prefix_type == 'nomic':
-            input_texts = ['nomic: {}'.format(t) for t in input_texts]
+            input_texts = ['search_document: {}'.format(t) for t in input_texts]
         # doing nothing for bge, none, instruction models
 
         encoded_embeds: np.ndarray = self._do_encode(input_texts, batch_size)

--- a/src/encoder_model.py
+++ b/src/encoder_model.py
@@ -50,8 +50,13 @@ class RetrievalModel(DRESModel):
                 config._attn_implementation = "flash_attention_2"
                 config.use_cache = False
                 config.sliding_window=None
+
+        model_kwargs = {}
+        # needed for nomic dynamic ntk rope scaling
+        if args.rotary_scaling_factor:
+            model_kwargs["rotary_scaling_factor"] = args.rotary_scaling_factor
         
-        self.encoder = AutoModel.from_pretrained(args.model_name_or_path, torch_dtype=torch.float16 if args.use_fp16 else torch.float32, config=config, ignore_mismatched_sizes=False, trust_remote_code=True)
+        self.encoder = AutoModel.from_pretrained(args.model_name_or_path, torch_dtype=torch.float16 if args.use_fp16 else torch.float32, config=config, ignore_mismatched_sizes=False, trust_remote_code=True, **model_kwargs)
             
         self.tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path)
         

--- a/src/utils.py
+++ b/src/utils.py
@@ -307,6 +307,7 @@ def get_args(input_args: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument("--no_l2_norm", action="store_true", default=False)
     parser.add_argument("--use_xformers", action="store_true", default=False)
     parser.add_argument("--use_self_extend", action="store_true", default=False)
+    parser.add_argument("--rotary_scaling_factor", type=int, default=None)
 
     args = parser.parse_args(input_args)
 


### PR DESCRIPTION
* use `search_document` as prefix instead of `nomic`
* allow for `rotary_scale_fator` to be passed as a param

Results 
```json
{
  "LEMBNeedleRetrieval": {
    "256": 0.88,
    "512": 0.64,
    "1024": 0.2,
    "2048": 0.14,
    "4096": 0.36,
    "8192": 0.56,
    "16384": 0.26,
    "32768": 0.12,
    "avg": 0.395
  },
  "LEMBPasskeyRetrieval": {
    "256": 1,
    "512": 0.98,
    "1024": 1,
    "2048": 0.96,
    "4096": 0.56,
    "8192": 0.2,
    "16384": 0.14,
    "32768": 0.02,
    "avg": 0.6074999999999999
  },
  "LEMBNarrativeQARetrieval": {
    "ndcg@1": 0.31247,
    "ndcg@10": 0.41234
  },
  "LEMBQMSumRetrieval": {
    "ndcg@1": 0.24034,
    "ndcg@10": 0.36651
  },
  "LEMBSummScreenFDRetrieval": {
    "ndcg@1": 0.86012,
    "ndcg@10": 0.92974
  },
  "LEMBWikimQARetrieval": {
    "ndcg@1": 0.63667,
    "ndcg@10": 0.73754
  }
}
```
Command to reproduce:
`python src/test_long_embed.py --model_name_or_path nomic-ai/nomic-embed-text-v1 --output_dir=./results --window_length_list 256 512 1024 2048 4096 8192 16384 32768 --batch_size 8 --use_fp16 --task_list "LEMBSummScreenFDRetrieval" "LEMBQMSumRetrieval" "LEMBWikimQARetrieval" "LEMBNarrativeQARetrieval" "LEMBNeedleRetrieval" "LEMBPasskeyRetrieval" --encode_max_length=8192 --rotary_scaling_factor=16`